### PR TITLE
Build manylinux x86_64 and i686 for 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,12 +71,12 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
+        - PLAT=i686
         - NP_BUILD_DEP=numpy==1.9.3
         - NP_TEST_DEP=numpy==1.11.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
         - NP_BUILD_DEP=numpy==1.11.3
         - NP_TEST_DEP=numpy==1.11.3
         - SCIPY_DEP=scipy


### PR DESCRIPTION
It looks like the flag `PLAT=i686` is being set in the wrong places in the matrix: 3.5 has only a x86_64 wheel, and 3.6 has only an i686 wheel (this is currently the case on PyPI for 0.18.2).

Is it possible to get those wheels uploaded to PyPI soon? I think a lot of continuous integration setups are probably messed up at the moment because of the lack of wheels for the current version.