### PR TITLE
[MRG] BLD Windows 32 bit nightly builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,7 @@ environment:
       PYTHON_VERSION: "3.6.0"
       PYTHON_ARCH: "32"
       NP_BUILD_DEP: "1.12.1"
+      DAILY_BUILD: "true"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.0"
@@ -62,6 +63,7 @@ environment:
       PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "32"
       NP_BUILD_DEP: "1.14.5"
+      DAILY_BUILD: "true"
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.0"


### PR DESCRIPTION
Because default installation from python.org on windows is...32bit.