### PR TITLE
MAINT Use cython 0.29.7 for building wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - UNICODE_WIDTH=32
     - NP_BUILD_DEP="numpy==1.8.2"
     - NP_TEST_DEP="numpy==1.13.1"
-    - CYTHON_BUILD_DEP="cython==0.28.5"
+    - CYTHON_BUILD_DEP="cython==0.29.7"
     - CYTHON_TEST_DEP="cython"
     - SCIPY_BUILD_DEP="scipy"
     - SCIPY_TEST_DEP="scipy"

--- a/appveyor/requirements.txt
+++ b/appveyor/requirements.txt
@@ -1,5 +1,5 @@
 scipy==1.1.0
-cython==0.28.5
+cython==0.29.7
 joblib
 pytest
 wheel


### PR DESCRIPTION
In preparation for the 0.21 release, use cython 0.29.7 (latest as of now) for building wheels.

Should close https://github.com/scikit-learn/scikit-learn/issues/13667  