### PR TITLE
0.21rc2 and Update build dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     - PLAT=x86_64
     - UNICODE_WIDTH=32
     - NP_BUILD_DEP="numpy==1.11.0"
-    - NP_TEST_DEP="numpy==1.16.1"
+    - NP_TEST_DEP="numpy"
     - CYTHON_BUILD_DEP="cython==0.29.7"
     - CYTHON_TEST_DEP="cython"
     - SCIPY_BUILD_DEP="scipy==0.17.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,11 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.5
+        - SCIPY_BUILD_DEP==0.17.0
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
-        - SCIPY_BUILD_DEP==0.17.0
+        - SCIPY_BUILD_DEP scipy==0.17.0
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
     - REPO_DIR="scikit-learn"
-    - BUILD_COMMIT=0.21rc1testing
+    - BUILD_COMMIT=0.21rc2
     - PLAT=x86_64
     - UNICODE_WIDTH=32
     - NP_BUILD_DEP="numpy==1.11.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - NP_TEST_DEP="numpy"
     - CYTHON_BUILD_DEP="cython==0.29.7"
     - CYTHON_TEST_DEP="cython"
-    - SCIPY_BUILD_DEP="scipy==0.17.0"
+    - SCIPY_BUILD_DEP="scipy"
     - SCIPY_TEST_DEP="scipy"
     - JOBLIB_BUILD_DEP="joblib==0.11"
     - JOBLIB_TEST_DEP="joblib"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
-        - SCIPY_BUILD_DEP scipy==0.17.0
+        - SCIPY_BUILD_DEP=scipy==0.17.0
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
     - REPO_DIR="scikit-learn"
-    - BUILD_COMMIT=0.21rc1
+    - BUILD_COMMIT=0.21rc1testing
     - PLAT=x86_64
     - UNICODE_WIDTH=32
     - NP_BUILD_DEP="numpy==1.11.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
-        - SCIPY_BUILD_DEP=scipy==0.17.0
+        - SCIPY_BUILD_DEP=scipy==0.17.1
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 env:
   global:
     - REPO_DIR="scikit-learn"
-    - BUILD_COMMIT=0.20.3
+    - BUILD_COMMIT=0.21rc1
     - PLAT=x86_64
     - UNICODE_WIDTH=32
-    - NP_BUILD_DEP="numpy==1.8.2"
-    - NP_TEST_DEP="numpy==1.13.1"
+    - NP_BUILD_DEP="numpy==1.11.0"
+    - NP_TEST_DEP="numpy==1.16.1"
     - CYTHON_BUILD_DEP="cython==0.29.7"
     - CYTHON_TEST_DEP="cython"
-    - SCIPY_BUILD_DEP="scipy"
+    - SCIPY_BUILD_DEP="scipy==0.17.0"
     - SCIPY_TEST_DEP="scipy"
+    - JOBLIB_BUILD_DEP="joblib==0.11"
+    - JOBLIB_TEST_DEP="joblib"
     - DAILY_COMMIT=master
     - DAILY_BUILD=false
     - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
@@ -30,87 +32,49 @@ matrix:
   include:
     - os: linux
       env:
-        - MB_PYTHON_VERSION=2.7
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - NP_TEST_DEP=numpy==1.9.3
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - PLAT=i686
-        - NP_TEST_DEP=numpy==1.9.3
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP=numpy==1.9.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.9.3
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.5
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
         - DAILY_BUILD=true
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.11.3
         - DAILY_BUILD=true
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.14.5
+        - NP_BUILD_DEP=numpy==1.16.1
+        - NP_TEST_DEP=numpy==1.16.1
         - DAILY_BUILD=true
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.14.5
+        - NP_BUILD_DEP=numpy==1.16.1
+        - NP_TEST_DEP=numpy==1.16.1
         - DAILY_BUILD=true
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=2.7
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.4
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP=numpy==1.9.3
-    - os: osx
-      language: generic
-      env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
+        - NP_BUILD_DEP=numpy==1.16.1
         - DAILY_BUILD=true
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=numpy==1.14.5
-        - NP_TEST_DEP=numpy==1.14.5
+        - NP_BUILD_DEP=numpy==1.16.1
+        - NP_TEST_DEP=numpy==1.16.1
         - DAILY_BUILD=true
 
 before_install:
@@ -126,8 +90,8 @@ before_install:
         UPLOAD_ARGS="--no-update-index"
     fi
   - echo "Building scikit-learn-$BUILD_COMMIT"
-  - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $SCIPY_BUILD_DEP"
-  - TEST_DEPENDS="$NP_TEST_DEP pytest $CYTHON_TEST_DEP $SCIPY_TEST_DEP"
+  - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $SCIPY_BUILD_DEP $JOBLIB_BUILD_DEP"
+  - TEST_DEPENDS="$NP_TEST_DEP pytest $CYTHON_TEST_DEP $SCIPY_TEST_DEP $JOBLIB_TEST_DEP"
   - source multibuild/common_utils.sh
   - source multibuild/travis_steps.sh
   - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,28 +58,25 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=numpy==1.16.1
-        - NP_TEST_DEP=numpy==1.16.1
+        - NP_BUILD_DEP=numpy==1.14.5
         - DAILY_BUILD=true
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.16.1
-        - NP_TEST_DEP=numpy==1.16.1
+        - NP_BUILD_DEP=numpy==1.14.5
         - DAILY_BUILD=true
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.16.1
+        - NP_BUILD_DEP=numpy==1.11.3
         - DAILY_BUILD=true
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=numpy==1.16.1
-        - NP_TEST_DEP=numpy==1.16.1
+        - NP_BUILD_DEP=numpy==1.14.5
         - DAILY_BUILD=true
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 
 environment:
   global:
-    BUILD_COMMIT: 0.21rc1
+    BUILD_COMMIT: 0.21rc1testing
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script interpreter
     # See: http://stackoverflow.com/a/13751649/163740

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,13 +46,13 @@ environment:
     - PYTHON: "C:\\Python37"
       PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "32"
-      NP_BUILD_DEP: "1.16.0"
+      NP_BUILD_DEP: "1.14.5"
       DAILY_BUILD: "true"
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "64"
-      NP_BUILD_DEP: "1.16.0"
+      NP_BUILD_DEP: "1.14.5"
       DAILY_BUILD: "true"
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 
 environment:
   global:
-    BUILD_COMMIT: 0.21rc1testing
+    BUILD_COMMIT: 0.21rc2
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script interpreter
     # See: http://stackoverflow.com/a/13751649/163740

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 
 environment:
   global:
-    BUILD_COMMIT: 0.20.3
+    BUILD_COMMIT: 0.21rc1
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script interpreter
     # See: http://stackoverflow.com/a/13751649/163740
@@ -23,22 +23,6 @@ environment:
     DAILY_BUILD: "false"
 
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.11"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.11"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.5"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.5"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "32"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
     SKLEARN_SKIP_NETWORK_TESTS: 1
     APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
     # Minimum numpy version
-    NP_BUILD_DEP: "1.10.4"
+    NP_BUILD_DEP: "1.11.0"
     DAILY_COMMIT: master
     DAILY_BUILD: "false"
 
@@ -46,13 +46,13 @@ environment:
     - PYTHON: "C:\\Python37"
       PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "32"
-      NP_BUILD_DEP: "1.14.5"
+      NP_BUILD_DEP: "1.16.0"
       DAILY_BUILD: "true"
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "64"
-      NP_BUILD_DEP: "1.14.5"
+      NP_BUILD_DEP: "1.16.0"
       DAILY_BUILD: "true"
 
 init:


### PR DESCRIPTION
* once merged, this should build wheels for 0.20rc1
* I've removed Py<3.5
* I've updated minimum numpy to 0.11
* I've allowed us to specify a joblib version for build and test but for now left build as minimum requirement and test as latest
* I've tried to drop redundant numpy versions specifications for travis.