### PR TITLE
Fix macos version matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - NP_TEST_DEP="numpy==1.16.3"
     - CYTHON_BUILD_DEP="cython==0.29.7"
     - CYTHON_TEST_DEP="cython"
-    - SCIPY_BUILD_DEP="scipy==0.17.1"
+    - SCIPY_BUILD_DEP="scipy==0.18.1"
     - SCIPY_TEST_DEP="scipy==1.3.0"
     - JOBLIB_BUILD_DEP="joblib==0.11"
     - JOBLIB_TEST_DEP="joblib"
@@ -66,7 +66,6 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.11.3
-        - SCIPY_BUILD_DEP=scipy==0.18.1
         - DAILY_BUILD=true
     - os: osx
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ env:
     - PLAT=x86_64
     - UNICODE_WIDTH=32
     - NP_BUILD_DEP="numpy==1.11.0"
-    - NP_TEST_DEP="numpy"
+    - NP_TEST_DEP="numpy==1.16.3"
     - CYTHON_BUILD_DEP="cython==0.29.7"
     - CYTHON_TEST_DEP="cython"
-    - SCIPY_BUILD_DEP="scipy"
-    - SCIPY_TEST_DEP="scipy"
+    - SCIPY_BUILD_DEP="scipy==0.17.1"
+    - SCIPY_TEST_DEP="scipy==1.3.0"
     - JOBLIB_BUILD_DEP="joblib==0.11"
     - JOBLIB_TEST_DEP="joblib"
     - DAILY_COMMIT=master
@@ -61,13 +61,11 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
-        - SCIPY_BUILD_DEP=scipy==0.17.1
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.11.3
-        - SCIPY_BUILD_DEP=scipy==0.17.1
         - DAILY_BUILD=true
     - os: osx
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - NP_TEST_DEP="numpy==1.16.3"
     - CYTHON_BUILD_DEP="cython==0.29.7"
     - CYTHON_TEST_DEP="cython"
-    - SCIPY_BUILD_DEP="scipy==0.18.1"
+    - SCIPY_BUILD_DEP="scipy"
     - SCIPY_TEST_DEP="scipy==1.3.0"
     - JOBLIB_BUILD_DEP="joblib==0.11"
     - JOBLIB_TEST_DEP="joblib"
@@ -33,19 +33,23 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
+        - SCIPY_BUILD_DEP="scipy==0.18.1"
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
         - PLAT=i686
+        - SCIPY_BUILD_DEP="scipy==0.18.1"
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - DAILY_BUILD=true
+        - SCIPY_BUILD_DEP="scipy==0.18.1"
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
         - DAILY_BUILD=true
+        - SCIPY_BUILD_DEP="scipy==0.18.1"
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
@@ -61,12 +65,14 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
+        - SCIPY_BUILD_DEP="scipy==0.18.1"
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.11.3
         - DAILY_BUILD=true
+        - SCIPY_BUILD_DEP="scipy==0.18.1"
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,40 +37,37 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.5
         - PLAT=i686
-    - os: osx
-      language: generic
+    - os: linux
       env:
-        - MB_PYTHON_VERSION=3.5
+        - MB_PYTHON_VERSION=3.6
+        - DAILY_BUILD=true
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=i686
+        - DAILY_BUILD=true
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - NP_BUILD_DEP=numpy==1.14.5
+        - DAILY_BUILD=true
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=i686
+        - NP_BUILD_DEP=numpy==1.14.5
+        - DAILY_BUILD=true
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.5
         - SCIPY_BUILD_DEP=scipy==0.17.1
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - DAILY_BUILD=true
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
-        - DAILY_BUILD=true
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=numpy==1.14.5
-        - DAILY_BUILD=true
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.14.5
-        - DAILY_BUILD=true
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.11.3
+        - SCIPY_BUILD_DEP=scipy==0.17.1
         - DAILY_BUILD=true
     - os: osx
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.11.3
+        - SCIPY_BUILD_DEP=scipy==1.18.1
         - DAILY_BUILD=true
     - os: osx
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.11.3
-        - SCIPY_BUILD_DEP=scipy==1.18.1
+        - SCIPY_BUILD_DEP=scipy==0.18.1
         - DAILY_BUILD=true
     - os: osx
       language: generic


### PR DESCRIPTION
I think I understand the issue described in scikit-learn/scikit-learn/pull/13915#issuecomment-495319072:

The test dependencies are not updated to the latest stable automatically: so it can be the case that building on old numpy could run the tests on a too recent version of scipy that would cause problem at test time.

Let's see if pinning everything fixes the problem.