### PR TITLE
Python 3.5 for 0.22.X

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,13 @@ jobs:
       name: windows
       vmImage: vs2017-win2016
       matrix:
+        py_3.5_32:
+          PYTHON_VERSION: "3.5.x"
+          PYTHON_ARCH: "x86"
+          NP_BUILD_DEP: "1.12.1"
+        py_3.5_64:
+          PYTHON_VERSION: "3.5.x"
+          NP_BUILD_DEP: "1.12.1"
         py_3.6_32:
           PYTHON_VERSION: "3.6.x"
           PYTHON_ARCH: "x86"
@@ -46,6 +53,11 @@ jobs:
       name: linux
       vmImage: ubuntu-16.04
       matrix:
+        py_3.5_32:
+          MB_PYTHON_VERSION: "3.5"
+          PLAT: "i686"
+        py_3.5_64:
+          MB_PYTHON_VERSION: "3.5"
         py_3.6_32:
           MB_PYTHON_VERSION: "3.6"
           PLAT: "i686"
@@ -75,6 +87,9 @@ jobs:
       name: macOS
       vmImage: xcode9-macos10.13
       matrix:
+        py_3.5_64:
+          MB_PYTHON_VERSION: "3.5"
+          NP_BUILD_DEP: "numpy==1.13.3"
         py_3.6_64:
           MB_PYTHON_VERSION: "3.6"
           NP_BUILD_DEP: "numpy==1.13.3"


### PR DESCRIPTION
Python 3.5 was removed from the matrix during the move to azure pipelines but 0.22.X still support py35.