### PR TITLE
MNT Only run upload to anaconda when both secrets are defined

### DIFF
--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -25,89 +25,79 @@ jobs:
         ${{ insert }}: ${{ parameters.matrix }}
 
     steps:
-      - checkout: self
-        submodules: true
+      # - checkout: self
+      #   submodules: true
 
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(MB_PYTHON_VERSION)
-        displayName: Set python version
+      # - task: UsePythonVersion@0
+      #   inputs:
+      #     versionSpec: $(MB_PYTHON_VERSION)
+      #   displayName: Set python version
 
-      - bash: |
-          set -e
+      # - bash: |
+      #     set -e
 
-          SKIP_BUILD="false"
-          if [ "$BUILD_REASON" == "Schedule" ]; then
-            BUILD_COMMIT=$NIGHTLY_BUILD_COMMIT
-            if [ "$NIGHTLY_BUILD" != "true" ]; then
-              SKIP_BUILD="true"
-            fi
-          fi
-          echo "Building scikit-learn@$BUILD_COMMIT"
-          echo "##vso[task.setvariable variable=BUILD_COMMIT]$BUILD_COMMIT"
-          echo "##vso[task.setvariable variable=SKIP_BUILD]$SKIP_BUILD"
+      #     SKIP_BUILD="false"
+      #     if [ "$BUILD_REASON" == "Schedule" ]; then
+      #       BUILD_COMMIT=$NIGHTLY_BUILD_COMMIT
+      #       if [ "$NIGHTLY_BUILD" != "true" ]; then
+      #         SKIP_BUILD="true"
+      #       fi
+      #     fi
+      #     echo "Building scikit-learn@$BUILD_COMMIT"
+      #     echo "##vso[task.setvariable variable=BUILD_COMMIT]$BUILD_COMMIT"
+      #     echo "##vso[task.setvariable variable=SKIP_BUILD]$SKIP_BUILD"
 
-          # Platform variables used in multibuild scripts
-          if [ `uname` == 'Darwin' ]; then
-            echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]osx"
-            echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]10.9"
-          else
-            echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]linux"
-          fi
+      #     # Platform variables used in multibuild scripts
+      #     if [ `uname` == 'Darwin' ]; then
+      #       echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]osx"
+      #       echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]10.9"
+      #     else
+      #       echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]linux"
+      #     fi
 
-          # Store original Python path to be able to create test_venv pointing
-          # to same Python version.
-          PYTHON_EXE=`which python`
-          echo "##vso[task.setvariable variable=PYTHON_EXE]$PYTHON_EXE"
-        displayName: Define build env variables
+      #     # Store original Python path to be able to create test_venv pointing
+      #     # to same Python version.
+      #     PYTHON_EXE=`which python`
+      #     echo "##vso[task.setvariable variable=PYTHON_EXE]$PYTHON_EXE"
+      #   displayName: Define build env variables
 
-      - bash: |
-          set -e
-          pip install virtualenv
-          BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $SCIPY_BUILD_DEP"
+      # - bash: |
+      #     set -e
+      #     pip install virtualenv
+      #     BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $SCIPY_BUILD_DEP"
 
-          source multibuild/common_utils.sh
-          source multibuild/travis_steps.sh
-          source extra_functions.sh
+      #     source multibuild/common_utils.sh
+      #     source multibuild/travis_steps.sh
+      #     source extra_functions.sh
 
-          # Setup build dependencies
-          before_install
+      #     # Setup build dependencies
+      #     before_install
 
-          # OpenMP is not present on macOS by default
-          setup_compiler
-          clean_code $REPO_DIR $BUILD_COMMIT
-          build_wheel $REPO_DIR $PLAT
-          teardown_compiler
-        displayName: Build wheel
-        condition: eq(variables['SKIP_BUILD'], 'false')
+      #     # OpenMP is not present on macOS by default
+      #     setup_compiler
+      #     clean_code $REPO_DIR $BUILD_COMMIT
+      #     build_wheel $REPO_DIR $PLAT
+      #     teardown_compiler
+      #   displayName: Build wheel
+      #   condition: eq(variables['SKIP_BUILD'], 'false')
 
-      - bash: |
-          set -xe
-          source multibuild/common_utils.sh
-          source multibuild/travis_steps.sh
-          source extra_functions.sh
-          setup_test_venv
-          install_run $PLAT
-          teardown_test_venv
-        displayName: Install wheel and test
-        condition: eq(variables['SKIP_BUILD'], 'false')
+      # - bash: |
+      #     set -xe
+      #     source multibuild/common_utils.sh
+      #     source multibuild/travis_steps.sh
+      #     source extra_functions.sh
+      #     setup_test_venv
+      #     install_run $PLAT
+      #     teardown_test_venv
+      #   displayName: Install wheel and test
+      #   condition: eq(variables['SKIP_BUILD'], 'false')
 
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
-          testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-        displayName: 'Publish Test Results'
-        condition: eq(variables['SKIP_BUILD'], 'false')
-
-      - bash: |
-          echo "##vso[task.prependpath]$CONDA/bin"
-          sudo chown -R $USER $CONDA
-        displayName: Add conda to PATH
-        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'))
-
-      - bash: conda install -q -y anaconda-client
-        displayName: Install anaconda-client
-        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'))
+      # - task: PublishTestResults@2
+      #   inputs:
+      #     testResultsFiles: "$(TEST_DIR)/$(JUNITXML)"
+      #     testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
+      #   displayName: "Publish Test Results"
+      #   condition: eq(variables['SKIP_BUILD'], 'false')
 
       - bash: |
           set -e
@@ -118,24 +108,29 @@ jobs:
             ANACONDA_ORG="scikit-learn-wheels-staging"
             TOKEN="$SCIKIT_LEARN_STAGING_UPLOAD_TOKEN"
           fi
-          if [ "$TOKEN" == "" ]; then
-            echo "##[warning] Could not find anaconda.org upload token in secret variables"
-          fi
           echo "##vso[task.setvariable variable=TOKEN]$TOKEN"
           echo "##vso[task.setvariable variable=ANACONDA_ORG]$ANACONDA_ORG"
         displayName: Retrieve secret upload token
-        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'))
+        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'), variables['SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN'], variables['SCIKIT_LEARN_STAGING_UPLOAD_TOKEN'])
         env:
           # Secret variables need to mapped to env variables explicitly:
           SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN: $(SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN)
           SCIKIT_LEARN_STAGING_UPLOAD_TOKEN: $(SCIKIT_LEARN_STAGING_UPLOAD_TOKEN)
 
+      - bash: echo "##vso[task.prependpath]$CONDA/Scripts"
+        displayName: Add conda to PATH
+        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'), variables['TOKEN'])
+
+      - bash: conda install -q -y anaconda-client
+        displayName: Install anaconda-client
+        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'), variables['TOKEN'])
+
       - bash: |
           set -e
           # The --force option forces a replacement if the remote file already
           # exists.
-          ls wheelhouse/*.whl
-          anaconda -t $TOKEN upload --force -u $ANACONDA_ORG wheelhouse/*.whl
+          ls scikit-learn/dist/scikit_learn-*.whl
+          anaconda -t $TOKEN upload --force -u $ANACONDA_ORG scikit-learn/dist/scikit_learn-*.whl
           echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
         displayName: Upload to anaconda.org (only if secret token is retrieved)
-        condition: ne(variables['TOKEN'], '')
+        condition: variables['TOKEN']

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -25,13 +25,13 @@ jobs:
         ${{ insert }}: ${{ parameters.matrix }}
 
     steps:
-      # - checkout: self
-      #   submodules: true
+      - checkout: self
+        submodules: true
 
-      # - task: UsePythonVersion@0
-      #   inputs:
-      #     versionSpec: $(MB_PYTHON_VERSION)
-      #   displayName: Set python version
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(MB_PYTHON_VERSION)
+        displayName: Set python version
 
       - bash: |
           set -e
@@ -55,49 +55,49 @@ jobs:
             echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]linux"
           fi
 
-      #     # Store original Python path to be able to create test_venv pointing
-      #     # to same Python version.
-      #     PYTHON_EXE=`which python`
-      #     echo "##vso[task.setvariable variable=PYTHON_EXE]$PYTHON_EXE"
-      #   displayName: Define build env variables
+          # Store original Python path to be able to create test_venv pointing
+          # to same Python version.
+          PYTHON_EXE=`which python`
+          echo "##vso[task.setvariable variable=PYTHON_EXE]$PYTHON_EXE"
+        displayName: Define build env variables
 
-      # - bash: |
-      #     set -e
-      #     pip install virtualenv
-      #     BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $SCIPY_BUILD_DEP"
+      - bash: |
+          set -e
+          pip install virtualenv
+          BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $SCIPY_BUILD_DEP"
 
-      #     source multibuild/common_utils.sh
-      #     source multibuild/travis_steps.sh
-      #     source extra_functions.sh
+          source multibuild/common_utils.sh
+          source multibuild/travis_steps.sh
+          source extra_functions.sh
 
-      #     # Setup build dependencies
-      #     before_install
+          # Setup build dependencies
+          before_install
 
-      #     # OpenMP is not present on macOS by default
-      #     setup_compiler
-      #     clean_code $REPO_DIR $BUILD_COMMIT
-      #     build_wheel $REPO_DIR $PLAT
-      #     teardown_compiler
-      #   displayName: Build wheel
-      #   condition: eq(variables['SKIP_BUILD'], 'false')
+          # OpenMP is not present on macOS by default
+          setup_compiler
+          clean_code $REPO_DIR $BUILD_COMMIT
+          build_wheel $REPO_DIR $PLAT
+          teardown_compiler
+        displayName: Build wheel
+        condition: eq(variables['SKIP_BUILD'], 'false')
 
-      # - bash: |
-      #     set -xe
-      #     source multibuild/common_utils.sh
-      #     source multibuild/travis_steps.sh
-      #     source extra_functions.sh
-      #     setup_test_venv
-      #     install_run $PLAT
-      #     teardown_test_venv
-      #   displayName: Install wheel and test
-      #   condition: eq(variables['SKIP_BUILD'], 'false')
+      - bash: |
+          set -xe
+          source multibuild/common_utils.sh
+          source multibuild/travis_steps.sh
+          source extra_functions.sh
+          setup_test_venv
+          install_run $PLAT
+          teardown_test_venv
+        displayName: Install wheel and test
+        condition: eq(variables['SKIP_BUILD'], 'false')
 
-      # - task: PublishTestResults@2
-      #   inputs:
-      #     testResultsFiles: "$(TEST_DIR)/$(JUNITXML)"
-      #     testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-      #   displayName: "Publish Test Results"
-      #   condition: eq(variables['SKIP_BUILD'], 'false')
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: "$(TEST_DIR)/$(JUNITXML)"
+          testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
+        displayName: "Publish Test Results"
+        condition: eq(variables['SKIP_BUILD'], 'false')
 
       - bash: |
           set -e

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -33,27 +33,27 @@ jobs:
       #     versionSpec: $(MB_PYTHON_VERSION)
       #   displayName: Set python version
 
-      # - bash: |
-      #     set -e
+      - bash: |
+          set -e
 
-      #     SKIP_BUILD="false"
-      #     if [ "$BUILD_REASON" == "Schedule" ]; then
-      #       BUILD_COMMIT=$NIGHTLY_BUILD_COMMIT
-      #       if [ "$NIGHTLY_BUILD" != "true" ]; then
-      #         SKIP_BUILD="true"
-      #       fi
-      #     fi
-      #     echo "Building scikit-learn@$BUILD_COMMIT"
-      #     echo "##vso[task.setvariable variable=BUILD_COMMIT]$BUILD_COMMIT"
-      #     echo "##vso[task.setvariable variable=SKIP_BUILD]$SKIP_BUILD"
+          SKIP_BUILD="false"
+          if [ "$BUILD_REASON" == "Schedule" ]; then
+            BUILD_COMMIT=$NIGHTLY_BUILD_COMMIT
+            if [ "$NIGHTLY_BUILD" != "true" ]; then
+              SKIP_BUILD="true"
+            fi
+          fi
+          echo "Building scikit-learn@$BUILD_COMMIT"
+          echo "##vso[task.setvariable variable=BUILD_COMMIT]$BUILD_COMMIT"
+          echo "##vso[task.setvariable variable=SKIP_BUILD]$SKIP_BUILD"
 
-      #     # Platform variables used in multibuild scripts
-      #     if [ `uname` == 'Darwin' ]; then
-      #       echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]osx"
-      #       echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]10.9"
-      #     else
-      #       echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]linux"
-      #     fi
+          # Platform variables used in multibuild scripts
+          if [ `uname` == 'Darwin' ]; then
+            echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]osx"
+            echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]10.9"
+          else
+            echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]linux"
+          fi
 
       #     # Store original Python path to be able to create test_venv pointing
       #     # to same Python version.

--- a/azure/posix.yml
+++ b/azure/posix.yml
@@ -94,9 +94,9 @@ jobs:
 
       - task: PublishTestResults@2
         inputs:
-          testResultsFiles: "$(TEST_DIR)/$(JUNITXML)"
+          testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
           testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-        displayName: "Publish Test Results"
+        displayName: 'Publish Test Results'
         condition: eq(variables['SKIP_BUILD'], 'false')
 
       - bash: |
@@ -129,8 +129,8 @@ jobs:
           set -e
           # The --force option forces a replacement if the remote file already
           # exists.
-          ls scikit-learn/dist/scikit_learn-*.whl
-          anaconda -t $TOKEN upload --force -u $ANACONDA_ORG scikit-learn/dist/scikit_learn-*.whl
+          ls wheelhouse/*.whl
+          anaconda -t $TOKEN upload --force -u $ANACONDA_ORG wheelhouse/*.whl
           echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
         displayName: Upload to anaconda.org (only if secret token is retrieved)
         condition: variables['TOKEN']

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -42,25 +42,25 @@ jobs:
       #     pip --version
       #   displayName: Check that we have the expected version and architecture for Python
 
-      # - bash: |
-      #     set -e
+      - bash: |
+          set -e
 
-      #     SKIP_BUILD="false"
-      #     if [ "$BUILD_REASON" == "Schedule" ]; then
-      #       BUILD_COMMIT=$NIGHTLY_BUILD_COMMIT
-      #       if [ "$NIGHTLY_BUILD" != "true" ]; then
-      #         SKIP_BUILD="true"
-      #       fi
-      #     fi
-      #     echo "Building scikit-learn@$BUILD_COMMIT"
-      #     echo "##vso[task.setvariable variable=BUILD_COMMIT]$BUILD_COMMIT"
-      #     echo "##vso[task.setvariable variable=SKIP_BUILD]$SKIP_BUILD"
+          SKIP_BUILD="false"
+          if [ "$BUILD_REASON" == "Schedule" ]; then
+            BUILD_COMMIT=$NIGHTLY_BUILD_COMMIT
+            if [ "$NIGHTLY_BUILD" != "true" ]; then
+              SKIP_BUILD="true"
+            fi
+          fi
+          echo "Building scikit-learn@$BUILD_COMMIT"
+          echo "##vso[task.setvariable variable=BUILD_COMMIT]$BUILD_COMMIT"
+          echo "##vso[task.setvariable variable=SKIP_BUILD]$SKIP_BUILD"
 
-      #     # Store original Python path to be able to create test_venv pointing
-      #     # to same Python version.
-      #     PYTHON_EXE=`which python`
-      #     echo "##vso[task.setvariable variable=PYTHON_EXE]$PYTHON_EXE"
-      #   displayName: Define build env variables
+          # Store original Python path to be able to create test_venv pointing
+          # to same Python version.
+          PYTHON_EXE=`which python`
+          echo "##vso[task.setvariable variable=PYTHON_EXE]$PYTHON_EXE"
+        displayName: Define build env variables
 
       # - bash: |
       #     set -e

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -18,103 +18,95 @@ jobs:
       PYTHON_ARCH: "x64"
       TEST_DEPENDS: "pytest"
       JUNITXML: "test-data.xml"
-      TEST_DIR: '$(Agent.WorkFolder)/tmp_for_test'
+      TEST_DIR: "$(Agent.WorkFolder)/tmp_for_test"
     strategy:
       matrix:
         ${{ insert }}: ${{ parameters.matrix }}
     steps:
-      - checkout: self
-        submodules: true
+      # - checkout: self
+      #   submodules: true
 
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
-          architecture: $(PYTHON_ARCH)
-        displayName: Set python version
+      # - task: UsePythonVersion@0
+      #   inputs:
+      #     versionSpec: $(PYTHON_VERSION)
+      #     architecture: $(PYTHON_ARCH)
+      #   displayName: Set python version
 
-      - bash: |
-          set -e
+      # - bash: |
+      #     set -e
 
-          echo PYTHON $PYTHON_VERSION $PYTHON_ARCH
-          echo Build Reason: $BUILD_REASON
-          python --version
-          python -c "import struct; print(struct.calcsize('P') * 8)"
-          pip --version
-        displayName: Check that we have the expected version and architecture for Python
+      #     echo PYTHON $PYTHON_VERSION $PYTHON_ARCH
+      #     echo Build Reason: $BUILD_REASON
+      #     python --version
+      #     python -c "import struct; print(struct.calcsize('P') * 8)"
+      #     pip --version
+      #   displayName: Check that we have the expected version and architecture for Python
 
-      - bash: |
-          set -e
+      # - bash: |
+      #     set -e
 
-          SKIP_BUILD="false"
-          if [ "$BUILD_REASON" == "Schedule" ]; then
-            BUILD_COMMIT=$NIGHTLY_BUILD_COMMIT
-            if [ "$NIGHTLY_BUILD" != "true" ]; then
-              SKIP_BUILD="true"
-            fi
-          fi
-          echo "Building scikit-learn@$BUILD_COMMIT"
-          echo "##vso[task.setvariable variable=BUILD_COMMIT]$BUILD_COMMIT"
-          echo "##vso[task.setvariable variable=SKIP_BUILD]$SKIP_BUILD"
+      #     SKIP_BUILD="false"
+      #     if [ "$BUILD_REASON" == "Schedule" ]; then
+      #       BUILD_COMMIT=$NIGHTLY_BUILD_COMMIT
+      #       if [ "$NIGHTLY_BUILD" != "true" ]; then
+      #         SKIP_BUILD="true"
+      #       fi
+      #     fi
+      #     echo "Building scikit-learn@$BUILD_COMMIT"
+      #     echo "##vso[task.setvariable variable=BUILD_COMMIT]$BUILD_COMMIT"
+      #     echo "##vso[task.setvariable variable=SKIP_BUILD]$SKIP_BUILD"
 
-          # Store original Python path to be able to create test_venv pointing
-          # to same Python version.
-          PYTHON_EXE=`which python`
-          echo "##vso[task.setvariable variable=PYTHON_EXE]$PYTHON_EXE"
-        displayName: Define build env variables
+      #     # Store original Python path to be able to create test_venv pointing
+      #     # to same Python version.
+      #     PYTHON_EXE=`which python`
+      #     echo "##vso[task.setvariable variable=PYTHON_EXE]$PYTHON_EXE"
+      #   displayName: Define build env variables
 
-      - bash: |
-          set -e
-          cd scikit-learn
-          git checkout $BUILD_COMMIT
-          git clean -fxd
-          git reset --hard
-        displayName: Checkout scikit-learn commit
-        condition: eq(variables['SKIP_BUILD'], 'false')
+      # - bash: |
+      #     set -e
+      #     cd scikit-learn
+      #     git checkout $BUILD_COMMIT
+      #     git clean -fxd
+      #     git reset --hard
+      #   displayName: Checkout scikit-learn commit
+      #   condition: eq(variables['SKIP_BUILD'], 'false')
 
-      - bash: |
-          set -e
+      # - bash: |
+      #     set -e
 
-          pip install --timeout=60 numpy==$NP_BUILD_DEP
-          pip install --timeout=60 pytest wheel joblib scipy==$SCIPY_BUILD_DEP Cython==$CYTHON_BUILD_DEP
-          pip install twine
+      #     pip install --timeout=60 numpy==$NP_BUILD_DEP
+      #     pip install --timeout=60 pytest wheel joblib scipy==$SCIPY_BUILD_DEP Cython==$CYTHON_BUILD_DEP
+      #     pip install twine
 
-          pushd scikit-learn
-          python setup.py build
-          python ../azure/vendor_vcomp140.py
-          python setup.py bdist_wheel
-          ls dist
-          twine check dist/*
-          popd
-        displayName: Build wheel
-        condition: eq(variables['SKIP_BUILD'], 'false')
+      #     pushd scikit-learn
+      #     python setup.py build
+      #     python ../azure/vendor_vcomp140.py
+      #     python setup.py bdist_wheel
+      #     ls dist
+      #     twine check dist/*
+      #     popd
+      #   displayName: Build wheel
+      #   condition: eq(variables['SKIP_BUILD'], 'false')
 
-      - bash: |
-          set -e
-          source extra_functions.sh
-          setup_test_venv
-          pip install scikit-learn/dist/scikit_learn-*.whl
-          mkdir $TEST_DIR
-          pushd $TEST_DIR
-          pytest -rs -l --junitxml=$JUNITXML --pyargs sklearn
-          popd
-          teardown_test_venv
-        displayName: Install wheel and test
-        condition: eq(variables['SKIP_BUILD'], 'false')
+      # - bash: |
+      #     set -e
+      #     source extra_functions.sh
+      #     setup_test_venv
+      #     pip install scikit-learn/dist/scikit_learn-*.whl
+      #     mkdir $TEST_DIR
+      #     pushd $TEST_DIR
+      #     pytest -rs -l --junitxml=$JUNITXML --pyargs sklearn
+      #     popd
+      #     teardown_test_venv
+      #   displayName: Install wheel and test
+      #   condition: eq(variables['SKIP_BUILD'], 'false')
 
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
-          testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-        displayName: 'Publish Test Results'
-        condition: eq(variables['SKIP_BUILD'], 'false')
-
-      - bash: echo "##vso[task.prependpath]$CONDA/Scripts"
-        displayName: Add conda to PATH
-        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'))
-
-      - bash: conda install -q -y anaconda-client
-        displayName: Install anaconda-client
-        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'))
+      # - task: PublishTestResults@2
+      #   inputs:
+      #     testResultsFiles: "$(TEST_DIR)/$(JUNITXML)"
+      #     testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
+      #   displayName: "Publish Test Results"
+      #   condition: eq(variables['SKIP_BUILD'], 'false')
 
       - bash: |
           set -e
@@ -125,17 +117,22 @@ jobs:
             ANACONDA_ORG="scikit-learn-wheels-staging"
             TOKEN="$SCIKIT_LEARN_STAGING_UPLOAD_TOKEN"
           fi
-          if [ "$TOKEN" == "" ]; then
-            echo "##[warning] Could not find anaconda.org upload token in secret variables"
-          fi
           echo "##vso[task.setvariable variable=TOKEN]$TOKEN"
           echo "##vso[task.setvariable variable=ANACONDA_ORG]$ANACONDA_ORG"
         displayName: Retrieve secret upload token
-        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'))
+        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'), variables['SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN'], variables['SCIKIT_LEARN_STAGING_UPLOAD_TOKEN'])
         env:
           # Secret variables need to mapped to env variables explicitly:
           SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN: $(SCIKIT_LEARN_NIGHTLY_UPLOAD_TOKEN)
           SCIKIT_LEARN_STAGING_UPLOAD_TOKEN: $(SCIKIT_LEARN_STAGING_UPLOAD_TOKEN)
+
+      - bash: echo "##vso[task.prependpath]$CONDA/Scripts"
+        displayName: Add conda to PATH
+        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'), variables['TOKEN'])
+
+      - bash: conda install -q -y anaconda-client
+        displayName: Install anaconda-client
+        condition: and(succeeded(), eq(variables['SKIP_BUILD'], 'false'), ne(variables['Build.Reason'], 'PullRequest'), variables['TOKEN'])
 
       - bash: |
           set -e
@@ -145,4 +142,4 @@ jobs:
           anaconda -t $TOKEN upload --force -u $ANACONDA_ORG scikit-learn/dist/scikit_learn-*.whl
           echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
         displayName: Upload to anaconda.org (only if secret token is retrieved)
-        condition: ne(variables['TOKEN'], '')
+        condition: variables['TOKEN']

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -23,24 +23,24 @@ jobs:
       matrix:
         ${{ insert }}: ${{ parameters.matrix }}
     steps:
-      # - checkout: self
-      #   submodules: true
+      - checkout: self
+        submodules: true
 
-      # - task: UsePythonVersion@0
-      #   inputs:
-      #     versionSpec: $(PYTHON_VERSION)
-      #     architecture: $(PYTHON_ARCH)
-      #   displayName: Set python version
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
+          architecture: $(PYTHON_ARCH)
+        displayName: Set python version
 
-      # - bash: |
-      #     set -e
+      - bash: |
+          set -e
 
-      #     echo PYTHON $PYTHON_VERSION $PYTHON_ARCH
-      #     echo Build Reason: $BUILD_REASON
-      #     python --version
-      #     python -c "import struct; print(struct.calcsize('P') * 8)"
-      #     pip --version
-      #   displayName: Check that we have the expected version and architecture for Python
+          echo PYTHON $PYTHON_VERSION $PYTHON_ARCH
+          echo Build Reason: $BUILD_REASON
+          python --version
+          python -c "import struct; print(struct.calcsize('P') * 8)"
+          pip --version
+        displayName: Check that we have the expected version and architecture for Python
 
       - bash: |
           set -e
@@ -62,51 +62,51 @@ jobs:
           echo "##vso[task.setvariable variable=PYTHON_EXE]$PYTHON_EXE"
         displayName: Define build env variables
 
-      # - bash: |
-      #     set -e
-      #     cd scikit-learn
-      #     git checkout $BUILD_COMMIT
-      #     git clean -fxd
-      #     git reset --hard
-      #   displayName: Checkout scikit-learn commit
-      #   condition: eq(variables['SKIP_BUILD'], 'false')
+      - bash: |
+          set -e
+          cd scikit-learn
+          git checkout $BUILD_COMMIT
+          git clean -fxd
+          git reset --hard
+        displayName: Checkout scikit-learn commit
+        condition: eq(variables['SKIP_BUILD'], 'false')
 
-      # - bash: |
-      #     set -e
+      - bash: |
+          set -e
 
-      #     pip install --timeout=60 numpy==$NP_BUILD_DEP
-      #     pip install --timeout=60 pytest wheel joblib scipy==$SCIPY_BUILD_DEP Cython==$CYTHON_BUILD_DEP
-      #     pip install twine
+          pip install --timeout=60 numpy==$NP_BUILD_DEP
+          pip install --timeout=60 pytest wheel joblib scipy==$SCIPY_BUILD_DEP Cython==$CYTHON_BUILD_DEP
+          pip install twine
 
-      #     pushd scikit-learn
-      #     python setup.py build
-      #     python ../azure/vendor_vcomp140.py
-      #     python setup.py bdist_wheel
-      #     ls dist
-      #     twine check dist/*
-      #     popd
-      #   displayName: Build wheel
-      #   condition: eq(variables['SKIP_BUILD'], 'false')
+          pushd scikit-learn
+          python setup.py build
+          python ../azure/vendor_vcomp140.py
+          python setup.py bdist_wheel
+          ls dist
+          twine check dist/*
+          popd
+        displayName: Build wheel
+        condition: eq(variables['SKIP_BUILD'], 'false')
 
-      # - bash: |
-      #     set -e
-      #     source extra_functions.sh
-      #     setup_test_venv
-      #     pip install scikit-learn/dist/scikit_learn-*.whl
-      #     mkdir $TEST_DIR
-      #     pushd $TEST_DIR
-      #     pytest -rs -l --junitxml=$JUNITXML --pyargs sklearn
-      #     popd
-      #     teardown_test_venv
-      #   displayName: Install wheel and test
-      #   condition: eq(variables['SKIP_BUILD'], 'false')
+      - bash: |
+          set -e
+          source extra_functions.sh
+          setup_test_venv
+          pip install scikit-learn/dist/scikit_learn-*.whl
+          mkdir $TEST_DIR
+          pushd $TEST_DIR
+          pytest -rs -l --junitxml=$JUNITXML --pyargs sklearn
+          popd
+          teardown_test_venv
+        displayName: Install wheel and test
+        condition: eq(variables['SKIP_BUILD'], 'false')
 
-      # - task: PublishTestResults@2
-      #   inputs:
-      #     testResultsFiles: "$(TEST_DIR)/$(JUNITXML)"
-      #     testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-      #   displayName: "Publish Test Results"
-      #   condition: eq(variables['SKIP_BUILD'], 'false')
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: "$(TEST_DIR)/$(JUNITXML)"
+          testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
+        displayName: "Publish Test Results"
+        condition: eq(variables['SKIP_BUILD'], 'false')
 
       - bash: |
           set -e

--- a/azure/windows.yml
+++ b/azure/windows.yml
@@ -18,7 +18,7 @@ jobs:
       PYTHON_ARCH: "x64"
       TEST_DEPENDS: "pytest"
       JUNITXML: "test-data.xml"
-      TEST_DIR: "$(Agent.WorkFolder)/tmp_for_test"
+      TEST_DIR: '$(Agent.WorkFolder)/tmp_for_test'
     strategy:
       matrix:
         ${{ insert }}: ${{ parameters.matrix }}
@@ -103,9 +103,9 @@ jobs:
 
       - task: PublishTestResults@2
         inputs:
-          testResultsFiles: "$(TEST_DIR)/$(JUNITXML)"
+          testResultsFiles: '$(TEST_DIR)/$(JUNITXML)'
           testRunTitle: ${{ format('{0}-$(Agent.JobName)', parameters.name) }}
-        displayName: "Publish Test Results"
+        displayName: 'Publish Test Results'
         condition: eq(variables['SKIP_BUILD'], 'false')
 
       - bash: |


### PR DESCRIPTION
The original `[ "$TOKEN" == "" ]` condition always returns false even if the secret is not defined. This has to do with how the variable is stored as a macro in azure.

This PR first checks if both upload secrets are defined before installing anaconda and uploading the wheel.

Aside: When `variables['TOKEN']` is null (not defined) it will evaluate to false.