### PR TITLE
MNT Uses github actions for uploading to pypi

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -36,12 +36,12 @@ jobs:
       uses: pypa/gh-action-pypi-publish@186232109eade3d22bfe1bca29ac9a1312598511
       with:
         user: __token__
-        password: ${{ secrets.TEST_PYPI_PASSWORD }}
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
       if: ${{ github.event.inputs.pypi_repo }} == 'testpypi'
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@186232109eade3d22bfe1bca29ac9a1312598511
       with:
         user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
+        password: ${{ secrets.PYPI_TOKEN }}
       if: ${{ github.event.inputs.pypi_repo }} == 'pypi'

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,47 @@
+name: Publish to Pypi
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version upload to pypi'
+        required: true
+      pypi_repo:
+        description: 'Repo to upload to (testpypi or pypi)'
+        default: 'testpypi'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        pip install -U wheelhouse_uploader pyyaml
+    - name: Downloading wheels and sdist from staging
+      run: |
+        echo "Download ${{ github.event.inputs.version }} wheels and sdist"
+        python -m wheelhouse_uploader fetch \
+          --version ${{ github.event.inputs.version }} \
+          --local-folder dist/ \
+          scikit-learn \
+          https://pypi.anaconda.org/scikit-learn-wheels-staging/simple/scikit-learn/
+    - name: Check dist has the correct number of artifacts
+      run: |
+        python check_artifacts.py
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@186232109eade3d22bfe1bca29ac9a1312598511
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_PASSWORD }}
+        repository_url: https://test.pypi.org/legacy/
+      if: ${{ github.event.inputs.pypi_repo }} == 'testpypi'
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@186232109eade3d22bfe1bca29ac9a1312598511
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}
+      if: ${{ github.event.inputs.pypi_repo }} == 'pypi'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv
+dist

--- a/check_artifacts.py
+++ b/check_artifacts.py
@@ -1,0 +1,32 @@
+"""Checks that dist/* contains the number of artifacts built from the
+azure-pipelines.yml config."""
+import sys
+from pathlib import Path
+import yaml
+
+azure_config_path = Path("azure-pipelines.yml")
+dist_dir = Path("dist")
+
+if not dist_dir.exists():
+    print("dist directory does not exist")
+    sys.exit(1)
+
+n_dist_files = len(list(dist_dir.glob('**/*')))
+
+# get number of artifacts built with azure-pipelines.yaml
+with azure_config_path.open('r') as f:
+    azure_config = yaml.safe_load(f)
+
+n_artifacts = 0
+for job in azure_config['jobs']:
+    if 'parameters' not in job:  # sdist
+        n_artifacts += 1
+        continue
+    n_artifacts += len(job['parameters']['matrix'])
+
+if n_dist_files != n_artifacts:
+    print(f"Expected {n_artifacts} artifacts in dist/* but "
+          f"got {n_dist_files} artifacts instead.")
+    sys.exit(1)
+
+print(f"dist/* has the expected {n_artifacts} artifacts")


### PR DESCRIPTION
This PR adds a github action so we can upload with pypi through the interface.

<img width="1018" alt="Screen Shot 2020-09-15 at 3 09 20 PM" src="https://user-images.githubusercontent.com/5402633/93262556-6caf9480-f772-11ea-8dfa-d1b3b2bd83da.png">

1. One needs to add the `PYPI_TOKEN` secret to enable uploading to pypi. (I already added a `TEST_PYPI_TOKEN` for testpypi).
2. One has to type in `pypi` in the "Run workflow" UI to upload to pypi, otherwise it will upload to testpypi by default.
3. There is a `check_artifacts.py` script that makes sure that `wheelhouse_uploader` fetches the correctly number of artifacts based on the `azure-pipeline.yml` configuration.

CC @ogrisel